### PR TITLE
fix FM band

### DIFF
--- a/app/model/media/RadioModel.js
+++ b/app/model/media/RadioModel.js
@@ -1056,10 +1056,10 @@ SDL.RadioModel = Em.Object.create({
         data -= 2;
       }
 
-      if (data > 1079) {
-        data = 879;
-      } else if (data < 879) {
-        data = 1079
+      if (data > 1080) {
+        data = 875;
+      } else if (data < 875) {
+        data = 1080
       }
 
       this.setFrequencyInteger(Math.floor(data / 10));


### PR DESCRIPTION
Customer reported issue with incorrect process of boundary values for FM band.
By request FM band should be 87.5 - 108.0

SDL's request validation code contained correct values while displayy had an issue.
this is a fix for display issue.
@litvinenkoira, please review