### PR TITLE
fix extra letter in front of appName

### DIFF
--- a/app/view/info/appsView.js
+++ b/app/view/info/appsView.js
@@ -88,8 +88,6 @@ SDL.InfoAppsView = Em.ContainerView.create({
         SDL.SDLModel.driverDeviceInfo &&
         apps[i].deviceName == SDL.SDLModel.driverDeviceInfo.name);
 
-        var ownerMarker = driverDevice ? '"D" ' : '"P" ';
-
         appIndex = SDL.SDLModel.data.registeredApps.indexOf(apps[i]);
 
         this.get('listOfApplications.list.childViews').
@@ -97,7 +95,7 @@ SDL.InfoAppsView = Em.ContainerView.create({
                    action: driverDevice ? 'onActivateSDLApp' :
                      'onDeactivatePassengerApp',
                    target: 'SDL.SDLController',
-                   text: ownerMarker + apps[i].appName + ' - ' + apps[i].deviceName,
+                   text: apps[i].appName + ' - ' + apps[i].deviceName,
                    appName: apps[i].appName,
                    appID: apps[i].appID,
                    classNames: 'list-item button',


### PR DESCRIPTION
Customer reject implementation of extra letter as prefix in appName that tells if the App owned bt driver or by passenger.

Current fix is just remove of this implementation

@litvinenkoira, @dev-gh, please review