### PR TITLE
fix OnInteriorVehicleData should contain frequency and band params

### DIFF
--- a/app/model/media/RadioModel.js
+++ b/app/model/media/RadioModel.js
@@ -979,7 +979,14 @@ SDL.RadioModel = Em.Object.create({
     }
 
     SDL.RadioModel.toggleProperty('radioControlStruct.radioEnable');
-    this.sendRadioChangeNotification(['radioEnable']);
+    var data = this.getRadioControlData(true);
+    data = SDL.SDLController.filterObjectProperty(data, 'band');
+    if (data.band == 'FM' || data.band == 'AM') {
+      this.sendRadioChangeNotification(['radioEnable', 'frequencyInteger', 'frequencyFraction', 'band']);
+    } 
+    else {
+      this.sendRadioChangeNotification(['radioEnable']);
+    }
   },
 
   scanKeyPress: function() {


### PR DESCRIPTION
There is a request from to provide extra data in notification OnInteriorVehicleData by activation Radio on HMI.
Along "radioEnable" should be frequency and band parameters for FM, AM.

This is a fix of the issue

@litvinenkoira, @dev-gh, please review the change.