### PR TITLE
Fix wrong info messages when radio boundaries check failed

### DIFF
--- a/app/model/media/RadioModel.js
+++ b/app/model/media/RadioModel.js
@@ -1211,17 +1211,6 @@ SDL.RadioModel = Em.Object.create({
       ? data.band : this.radioControlStruct.band
     );
 
-    var getAvailableHDs = function() {
-      var currentRadioData = SDL.RadioModel.getRadioControlData(true);
-      currentRadioData = SDL.SDLController.filterObjectProperty(currentRadioData, 'availableHDs');
-      if (currentRadioData.availableHDs != null) {
-        return currentRadioData.availableHDs;
-      }
-      else {
-        return 0;
-      }
-    }
-
     if (band == 'FM') {
       if (data.frequencyInteger == null && data.frequencyFraction == null && data.hdChannel == null) {
         return resultTable;

--- a/ffw/RCRPC.js
+++ b/ffw/RCRPC.js
@@ -206,12 +206,14 @@ FFW.RC = FFW.RPCObserver.create(
                 );
                 return;
               }
-              if (!SDL.RadioModel.checkRadioFrequencyBoundaries(
-                    request.params.moduleData.radioControlData)) {
+              var result = SDL.RadioModel.checkRadioFrequencyBoundaries(
+                request.params.moduleData.radioControlData
+              );
+              if (!result.success) {
                 this.sendError(
                   SDL.SDLModel.data.resultCode.INVALID_DATA,
                   request.id, request.method,
-                  'Invalid radio frequency for desination radio band.'
+                  result.info
                 );
                 return;
               }


### PR DESCRIPTION
Also added new different info messages for several specific cases.
Removed redundant local function.
This fix allows HMI to respond with different info messages if validation was failed due to some reason.