### PR TITLE
Fix XM radio presets switching/saving logic

### DIFF
--- a/app/model/media/RadioModel.js
+++ b/app/model/media/RadioModel.js
@@ -1211,17 +1211,6 @@ SDL.RadioModel = Em.Object.create({
       ? data.band : this.radioControlStruct.band
     );
 
-    var getAvailableHDs = function() {
-      var currentRadioData = SDL.RadioModel.getRadioControlData(true);
-      currentRadioData = SDL.SDLController.filterObjectProperty(currentRadioData, 'availableHDs');
-      if (currentRadioData.availableHDs != null) {
-        return currentRadioData.availableHDs;
-      }
-      else {
-        return 0;
-      }
-    }
-
     if (band == 'FM') {
       if (data.frequencyInteger == null && data.frequencyFraction == null && data.hdChannel == null) {
         return resultTable;

--- a/app/model/media/RadioModel.js
+++ b/app/model/media/RadioModel.js
@@ -1285,14 +1285,23 @@ SDL.RadioModel = Em.Object.create({
     }
 
     if (band == 'XM') {
+      if (data.frequencyFraction != null) {
+        resultTable.success = false;
+        resultTable.info = 'Invalid radio frequency for desination radio band';
+        return resultTable;
+      }
       if (data.hdChannel != null) {
         resultTable.success = false;
         resultTable.info = 'HD channel is not supported for XM radio band';
         return resultTable;
       }
 
+      if (data.frequencyInteger == null) {
+        return resultTable;
+      }
+
       resultTable.success =
-        (data.frequencyInteger != null && data.frequencyInteger >= 1 && data.frequencyInteger <= 1710);
+        (data.frequencyInteger >= 1 && data.frequencyInteger <= 1710);
       resultTable.info = (resultTable.success ?
           '' : 'Invalid radio frequency for desination radio band');
 

--- a/app/model/media/RadioModel.js
+++ b/app/model/media/RadioModel.js
@@ -124,7 +124,7 @@ SDL.RadioModel = Em.Object.create({
     ]
   },
 
-  xmStations: {2: "SiriusXM Hits 1", 3: "Venus", 4: "SiriusXM Spotlight",
+  xmStations: {2: "SiriusXM Hits", 3: "Venus", 4: "SiriusXM Spotlight",
    5: "50s on 5", 6: "60s on 6", 7: "70s on 7", 8: "80s on 8", 9: "90s on 9",
    10: "Pop2K", 11: "KIIS-Los Angeles", 12: "Z100/NY", 13: "Pitbull", 14: "The Coffee House",
    15: "The Pulse", 16: "The Blend", 17: "PopRocks", 18: "The Beatles Channel",
@@ -411,48 +411,6 @@ SDL.RadioModel = Em.Object.create({
       }
     },
     'XM': {
-      '1': {
-        'radioStation': {
-          'availableHDs': 1,
-          'currentHD': 1
-        },
-        'songInfo': {
-          'name': 'Song1',
-          'artist': 'Artist1',
-          'genre': 'Genre1',
-          'album': 'Album1',
-          'year': 2001,
-          'duration': 10
-        }
-      },
-      '2': {
-        'radioStation': {
-          'availableHDs': 2,
-          'currentHD': 2
-        },
-        'songInfo': {
-          'name': 'Song2',
-          'artist': 'Artist2',
-          'genre': 'Genre2',
-          'album': 'Album2',
-          'year': 2002,
-          'duration': 20
-        }
-      },
-      '3': {
-        'radioStation': {
-          'availableHDs': 3,
-          'currentHD': 3
-        },
-        'songInfo': {
-          'name': 'Song3',
-          'artist': 'Artist3',
-          'genre': 'Genre3',
-          'album': 'Album3',
-          'year': 2003,
-          'duration': 30
-        }
-      }
     }
   },
 

--- a/app/view/media/player/radioView.js
+++ b/app/view/media/player/radioView.js
@@ -618,28 +618,28 @@ SDL.RadioView = Em.ContainerView
             .compile(
               '{{#with view}}' +
               '<div class="track-info">' +
-              '<div class = "HDRadio" style="display: inline-flex; align-items: center;">' + 
+              '<div class = "HDRadio" style="display: inline-flex; align-items: center;">' +
               '{{#if HDRadio}}' +
               '<img src="images/media/hd_logo.png" style="width:27px;height:27px;">' +
               '{{#if HDChannel1Availability}}' +
               '{{#if HDChannel1}}' +
-              '<span style="padding: 5px;color: orange;"> 1 </span>' + 
+              '<span style="padding: 5px;color: orange;"> 1 </span>' +
               '{{else}}' +
-              '<span style="padding: 5px;"> 1 </span>' + 
+              '<span style="padding: 5px;"> 1 </span>' +
               '{{/if}}' +
               '{{/if}}' +
               '{{#if HDChannel2Availability}}' +
               '{{#if HDChannel2}}' +
-              '<span style="padding: 5px;color: orange;"> 2 </span>' + 
+              '<span style="padding: 5px;color: orange;"> 2 </span>' +
               '{{else}}' +
-              '<span style="padding: 5px;"> 2 </span>' + 
+              '<span style="padding: 5px;"> 2 </span>' +
               '{{/if}}' +
               '{{/if}}' +
               '{{#if HDChannel3Availability}}' +
               '{{#if HDChannel3}}' +
-              '<span style="padding: 5px;color: orange;"> 3 </span>' + 
+              '<span style="padding: 5px;color: orange;"> 3 </span>' +
               '{{else}}' +
-              '<span style="padding: 5px;"> 3 </span>' + 
+              '<span style="padding: 5px;"> 3 </span>' +
               '{{/if}}' +
               '{{/if}}' +
               '{{/if}}' +

--- a/css/home.css
+++ b/css/home.css
@@ -130,10 +130,12 @@
 }
 
 .stationInfo {
-     width: 200px;
+     width: 165px;
      height: 50px;
      left: 86px;
      top: 29px;
+     overflow: hidden;
+     white-space: nowrap;
 }
 
 .stationInfo .station {

--- a/css/info.css
+++ b/css/info.css
@@ -658,6 +658,7 @@
 
 #info_apps .list-item span {
 	height: 23px;
+	white-space: nowrap;
 }
 
 #info_apps .inner-wrapper {

--- a/ffw/RCRPC.js
+++ b/ffw/RCRPC.js
@@ -206,12 +206,14 @@ FFW.RC = FFW.RPCObserver.create(
                 );
                 return;
               }
-              if (!SDL.RadioModel.checkRadioFrequencyBoundaries(
-                    request.params.moduleData.radioControlData)) {
+              var result = SDL.RadioModel.checkRadioFrequencyBoundaries(
+                request.params.moduleData.radioControlData
+              );
+              if (!result.success) {
                 this.sendError(
                   SDL.SDLModel.data.resultCode.INVALID_DATA,
                   request.id, request.method,
-                  'Invalid radio frequency for desination radio band.'
+                  result.info
                 );
                 return;
               }


### PR DESCRIPTION
Comment from Jack:

> XM Radio presets cause javascript error:
> 
> ```RadioModel.js:954 Uncaught TypeError: Object.values is not a function```
> 
> 

There was a problem that Object.values() function is not supported on old chromium browser versions so it was replaced with for loop.
Also there was a problem with searching active radio preset for XM which also was fixed.
Also was uncommented logic for saving XM presets using long press on preset button.