### PR TITLE
Fix HD channel logic in radio bands

### DIFF
--- a/app/model/media/RadioModel.js
+++ b/app/model/media/RadioModel.js
@@ -1211,17 +1211,6 @@ SDL.RadioModel = Em.Object.create({
       ? data.band : this.radioControlStruct.band
     );
 
-    var getAvailableHDs = function() {
-      var currentRadioData = SDL.RadioModel.getRadioControlData(true);
-      currentRadioData = SDL.SDLController.filterObjectProperty(currentRadioData, 'availableHDs');
-      if (currentRadioData.availableHDs != null) {
-        return currentRadioData.availableHDs;
-      }
-      else {
-        return 0;
-      }
-    }
-
     if (band == 'FM') {
       if (data.frequencyInteger == null && data.frequencyFraction == null && data.hdChannel == null) {
         return resultTable;

--- a/app/model/media/RadioModel.js
+++ b/app/model/media/RadioModel.js
@@ -826,7 +826,7 @@ SDL.RadioModel = Em.Object.create({
     var station = this.changeFrequency(0);
     var stationData = this.stationsData[band][station];
 
-    if (stationData != null) {
+    if (stationData != null && band != 'XM') {
       var availableHDs = stationData.radioStation.availableHDs;
       var hdChannel = stationData.radioStation.currentHD;
       hdChannel = (hdChannel < 1 && availableHDs > 0 ? 1 : hdChannel);
@@ -844,6 +844,9 @@ SDL.RadioModel = Em.Object.create({
 
   updateRadioStationHdChannelInfo: function(params) {
     var band = this.radioControlStruct.band;
+    if (band == 'XM') {
+      return;
+    }
     var station = this.changeFrequency(0);
     var stationData = this.stationsData[band][station];
 

--- a/app/model/media/RadioModel.js
+++ b/app/model/media/RadioModel.js
@@ -1285,14 +1285,23 @@ SDL.RadioModel = Em.Object.create({
     }
 
     if (band == 'XM') {
+      if (data.frequencyFraction != null) {
+        resultTable.success = false;
+        resultTable.info = 'Invalid radio frequency for desination radio band';
+        return resultTable;
+      }
       if (data.hdChannel != null) {
         resultTable.success = false;
         resultTable.info = 'HD channel is not supported for XM radio band';
         return resultTable;
       }
 
+      if (data.frequencyInteger == null) {
+        return resultTable;
+      }
+
       resultTable.success =
-        (data.frequencyInteger != null && data.frequencyInteger >= 1 && data.frequencyInteger <= 1710);
+        (data.frequencyInteger >= 1 && data.frequencyInteger <= 1710);
       resultTable.info = (resultTable.success ?
           '' : 'Invalid radio frequency for desination radio band');
 

--- a/app/model/media/RadioModel.js
+++ b/app/model/media/RadioModel.js
@@ -124,7 +124,7 @@ SDL.RadioModel = Em.Object.create({
     ]
   },
 
-  xmStations: {2: "SiriusXM Hits 1", 3: "Venus", 4: "SiriusXM Spotlight",
+  xmStations: {2: "SiriusXM Hits", 3: "Venus", 4: "SiriusXM Spotlight",
    5: "50s on 5", 6: "60s on 6", 7: "70s on 7", 8: "80s on 8", 9: "90s on 9",
    10: "Pop2K", 11: "KIIS-Los Angeles", 12: "Z100/NY", 13: "Pitbull", 14: "The Coffee House",
    15: "The Pulse", 16: "The Blend", 17: "PopRocks", 18: "The Beatles Channel",
@@ -411,48 +411,6 @@ SDL.RadioModel = Em.Object.create({
       }
     },
     'XM': {
-      '1': {
-        'radioStation': {
-          'availableHDs': 1,
-          'currentHD': 1
-        },
-        'songInfo': {
-          'name': 'Song1',
-          'artist': 'Artist1',
-          'genre': 'Genre1',
-          'album': 'Album1',
-          'year': 2001,
-          'duration': 10
-        }
-      },
-      '2': {
-        'radioStation': {
-          'availableHDs': 2,
-          'currentHD': 2
-        },
-        'songInfo': {
-          'name': 'Song2',
-          'artist': 'Artist2',
-          'genre': 'Genre2',
-          'album': 'Album2',
-          'year': 2002,
-          'duration': 20
-        }
-      },
-      '3': {
-        'radioStation': {
-          'availableHDs': 3,
-          'currentHD': 3
-        },
-        'songInfo': {
-          'name': 'Song3',
-          'artist': 'Artist3',
-          'genre': 'Genre3',
-          'album': 'Album3',
-          'year': 2003,
-          'duration': 30
-        }
-      }
     }
   },
 

--- a/app/model/media/RadioModel.js
+++ b/app/model/media/RadioModel.js
@@ -80,6 +80,7 @@ SDL.RadioModel = Em.Object.create({
   availableHDs: 3,
 
   hdChannelsStruct: [
+    0,
     1,
     2,
     3
@@ -247,12 +248,12 @@ SDL.RadioModel = Em.Object.create({
 
   stationsData: {
     'FM': {
-      '895': {
+      '879': {
         'radioStation': {
           'frequency': 89,
           'fraction': 5,
-          'availableHDs': 0,
-          'currentHD': 0
+          'availableHDs': 3,
+          'currentHD': 1
         },
         'songInfo': {
           'name': 'Song1',
@@ -267,8 +268,8 @@ SDL.RadioModel = Em.Object.create({
         'radioStation': {
           'frequency': 95,
           'fraction': 3,
-          'availableHDs': 0,
-          'currentHD': 0
+          'availableHDs': 2,
+          'currentHD': 1
         },
         'songInfo': {
           'name': 'Song2',
@@ -283,8 +284,8 @@ SDL.RadioModel = Em.Object.create({
         'radioStation': {
           'frequency': 100,
           'fraction': 1,
-          'availableHDs': 0,
-          'currentHD': 0
+          'availableHDs': 1,
+          'currentHD': 1
         },
         'songInfo': {
           'name': 'Song3',
@@ -315,8 +316,8 @@ SDL.RadioModel = Em.Object.create({
         'radioStation': {
           'frequency': 105,
           'fraction': 3,
-          'availableHDs': 0,
-          'currentHD': 0
+          'availableHDs': 3,
+          'currentHD': 1
         },
         'songInfo': {
           'name': 'Song5',
@@ -333,8 +334,8 @@ SDL.RadioModel = Em.Object.create({
         'radioStation': {
           'frequency': 89,
           'fraction': 5,
-          'availableHDs': 0,
-          'currentHD': 0
+          'availableHDs': 3,
+          'currentHD': 1
         },
         'songInfo': {
           'name': 'Song1',
@@ -349,8 +350,8 @@ SDL.RadioModel = Em.Object.create({
         'radioStation': {
           'frequency': 65,
           'fraction': 0,
-          'availableHDs': 0,
-          'currentHD': 0
+          'availableHDs': 2,
+          'currentHD': 1
         },
         'songInfo': {
           'name': 'Song2',
@@ -365,8 +366,8 @@ SDL.RadioModel = Em.Object.create({
         'radioStation': {
           'frequency': 800,
           'fraction': 0,
-          'availableHDs': 0,
-          'currentHD': 0
+          'availableHDs': 1,
+          'currentHD': 1
         },
         'songInfo': {
           'name': 'Song3',
@@ -397,8 +398,8 @@ SDL.RadioModel = Em.Object.create({
         'radioStation': {
           'frequency': 1450,
           'fraction': 0,
-          'availableHDs': 0,
-          'currentHD': 0
+          'availableHDs': 3,
+          'currentHD': 1
         },
         'songInfo': {
           'name': 'Song5',

--- a/app/model/media/RadioModel.js
+++ b/app/model/media/RadioModel.js
@@ -148,50 +148,6 @@ SDL.RadioModel = Em.Object.create({
    90: "SiriusXM NASCAR Radio", 91: "SiriusXM NHL Network Radio™", 93: "SiriusXM Rush",
    94: "SiriusXM Comedy Greats", 95: "Comedy Central Radio", 96: "The Foxxhole",
    97: "Jeff & Larrys Comedy Roundup", 98: "Laugh USA", 99: "Raw Dog Comedy Hits", 100: "Howard 100"},
-  presetMetaData: [
-      {
-        songInfo: {
-          genre: 'Pop',
-          name: 'BlUE SKY',
-          artist: 'THE MAX'
-        }
-      },
-      {
-        songInfo: {
-          genre: 'Club',
-          name: 'JUMP AND DOWN',
-          artist: 'THE PROJECT X'
-        }
-      },
-      {
-        songInfo: {
-          genre: 'Rock',
-          name: 'WELCOME HOME',
-          artist: 'TODD SULLIVAN'
-        }
-      },
-      {
-        songInfo: {
-          genre: 'Pop',
-          name: 'LETS DANCE',
-          artist: 'MICHAEL JOHNSON'
-        }
-      },
-      {
-        songInfo: {
-          genre: 'Pop Rock',
-          name: 'YESTERDAY NIGHT',
-          artist: 'JOHN SMITH'
-        }
-      },
-      {
-        songInfo: {
-          genre: 'Classic',
-          name: 'TENTH SYMPHONY',
-          artist: 'SPENCER M.'
-        }
-      }
-    ],
 
   directTuneItems: {
     'FM': [],

--- a/app/view/media/player/radioView.js
+++ b/app/view/media/player/radioView.js
@@ -618,28 +618,28 @@ SDL.RadioView = Em.ContainerView
             .compile(
               '{{#with view}}' +
               '<div class="track-info">' +
-              '<div class = "HDRadio" style="display: inline-flex; align-items: center;">' + 
+              '<div class = "HDRadio" style="display: inline-flex; align-items: center;">' +
               '{{#if HDRadio}}' +
               '<img src="images/media/hd_logo.png" style="width:27px;height:27px;">' +
               '{{#if HDChannel1Availability}}' +
               '{{#if HDChannel1}}' +
-              '<span style="padding: 5px;color: orange;"> 1 </span>' + 
+              '<span style="padding: 5px;color: orange;"> 1 </span>' +
               '{{else}}' +
-              '<span style="padding: 5px;"> 1 </span>' + 
+              '<span style="padding: 5px;"> 1 </span>' +
               '{{/if}}' +
               '{{/if}}' +
               '{{#if HDChannel2Availability}}' +
               '{{#if HDChannel2}}' +
-              '<span style="padding: 5px;color: orange;"> 2 </span>' + 
+              '<span style="padding: 5px;color: orange;"> 2 </span>' +
               '{{else}}' +
-              '<span style="padding: 5px;"> 2 </span>' + 
+              '<span style="padding: 5px;"> 2 </span>' +
               '{{/if}}' +
               '{{/if}}' +
               '{{#if HDChannel3Availability}}' +
               '{{#if HDChannel3}}' +
-              '<span style="padding: 5px;color: orange;"> 3 </span>' + 
+              '<span style="padding: 5px;color: orange;"> 3 </span>' +
               '{{else}}' +
-              '<span style="padding: 5px;"> 3 </span>' + 
+              '<span style="padding: 5px;"> 3 </span>' +
               '{{/if}}' +
               '{{/if}}' +
               '{{/if}}' +

--- a/app/view/media/player/radioView.js
+++ b/app/view/media/player/radioView.js
@@ -571,29 +571,42 @@ SDL.RadioView = Em.ContainerView
       info: Em.View.extend(
         {
           HDRadio: function() {
-            return (SDL.RadioModel.radioControlCheckboxes.availableHDs > 0);
-          }.property('SDL.RadioModel.radioControlCheckboxes.availableHDs'),
+            if (SDL.RadioModel.radioControlStruct.band == 'XM') {
+              return false;
+            }
+            return (SDL.RadioModel.radioControlStruct.availableHDs > 0);
+          }.property('SDL.RadioModel.radioControlStruct.band',
+                     'SDL.RadioModel.radioControlStruct.availableHDs'),
           HDChannel1: function() {
-            return (SDL.RadioModel.lastOptionParams.hdChannel == 1);
-          }.property('SDL.RadioModel.lastOptionParams.hdChannel'),
+            return (SDL.RadioModel.radioControlStruct.hdChannel == 1);
+          }.property('SDL.RadioModel.radioControlStruct.hdChannel'),
           HDChannel1Availability: function() {
-            return (SDL.RadioModel.lastOptionParams.availableHDs >= 1);
-          }.property('SDL.RadioModel.lastOptionParams.availableHDs'),
+            return (SDL.RadioModel.radioControlStruct.availableHDs >= 1);
+          }.property('SDL.RadioModel.radioControlStruct.availableHDs'),
           HDChannel2: function() {
-            return (SDL.RadioModel.lastOptionParams.hdChannel == 2);
-          }.property('SDL.RadioModel.lastOptionParams.hdChannel'),
+            return (SDL.RadioModel.radioControlStruct.hdChannel == 2);
+          }.property('SDL.RadioModel.radioControlStruct.hdChannel'),
           HDChannel2Availability: function() {
-            return (SDL.RadioModel.lastOptionParams.availableHDs >= 2);
-          }.property('SDL.RadioModel.lastOptionParams.availableHDs'),
+            return (SDL.RadioModel.radioControlStruct.availableHDs >= 2);
+          }.property('SDL.RadioModel.radioControlStruct.availableHDs'),
           HDChannel3: function() {
-            return (SDL.RadioModel.lastOptionParams.hdChannel == 3);
-          }.property('SDL.RadioModel.lastOptionParams.hdChannel'),
+            return (SDL.RadioModel.radioControlStruct.hdChannel == 3);
+          }.property('SDL.RadioModel.radioControlStruct.hdChannel'),
           HDChannel3Availability: function() {
-            return (SDL.RadioModel.lastOptionParams.availableHDs >= 3);
-          }.property('SDL.RadioModel.lastOptionParams.availableHDs'),
+            return (SDL.RadioModel.radioControlStruct.availableHDs >= 3);
+          }.property('SDL.RadioModel.radioControlStruct.availableHDs'),
           STAName: function() {
             return 'STA-' + SDL.RadioModel.station.toString().replace('.', '');
           }.property('SDL.RadioModel.station'),
+          StationName: function() {
+            var station = SDL.RadioModel.station;
+            if (SDL.RadioModel.radioControlStruct.availableHDs > 0) {
+              station += '-' + SDL.RadioModel.radioControlStruct.hdChannel;
+            }
+            return station;
+          }.property('SDL.RadioModel.station',
+                     'SDL.RadioModel.radioControlStruct.hdChannel',
+                     'SDL.RadioModel.radioControlStruct.availableHDs'),
           songInfo: function() {
             var data = SDL.RadioModel.radioDetails;
             if (data) {
@@ -645,7 +658,7 @@ SDL.RadioView = Em.ContainerView
               '{{/if}}' +
               '</div>' +
               '<div class="STAName">{{STAName}}</div>' +
-              '<div class="station">{{SDL.RadioModel.station}}</div>' +
+              '<div class="station">{{StationName}}</div>' +
               '<div class="divider_o"></div>' +
               '<div class="genre">{{SDL.RadioModel.radioDetails.songInfo.genre}}</div>' +
               '<div class="songInfo">{{songInfo}}</div>' +

--- a/app/view/media/player/radioView.js
+++ b/app/view/media/player/radioView.js
@@ -445,11 +445,15 @@ SDL.RadioView = Em.ContainerView
                   SDL.RadioModel.lastOptionParams.availableHDs);
                 result.splice(index + 1, index + result.length - 1);
                 var maxHdValue = result[result.length - 1];
-                if (SDL.RadioModel.lastOptionParams.hdChannel > maxHdValue) {
-                  SDL.RadioModel.set('lastOptionParams.hdChannel', maxHdValue);
+                if (maxHdValue > 0) {
+                  result.splice(0, 1);
                 }
-                if (!this.content || this.content.length != result.length) {
+                if (!this.content || result) {
                   this.set('content', result);
+                }
+                if (SDL.RadioModel.lastOptionParams.hdChannel === undefined ||
+                    SDL.RadioModel.lastOptionParams.hdChannel > maxHdValue) {
+                  SDL.RadioModel.set('lastOptionParams.hdChannel', maxHdValue);
                 }
               }.observes(
                 'SDL.RadioModel.lastOptionParams.availableHDs'

--- a/css/home.css
+++ b/css/home.css
@@ -130,10 +130,12 @@
 }
 
 .stationInfo {
-     width: 200px;
+     width: 165px;
      height: 50px;
      left: 86px;
      top: 29px;
+     overflow: hidden;
+     white-space: nowrap;
 }
 
 .stationInfo .station {

--- a/css/info.css
+++ b/css/info.css
@@ -658,6 +658,7 @@
 
 #info_apps .list-item span {
 	height: 23px;
+	white-space: nowrap;
 }
 
 #info_apps .inner-wrapper {

--- a/ffw/RCRPC.js
+++ b/ffw/RCRPC.js
@@ -206,12 +206,14 @@ FFW.RC = FFW.RPCObserver.create(
                 );
                 return;
               }
-              if (!SDL.RadioModel.checkRadioFrequencyBoundaries(
-                    request.params.moduleData.radioControlData)) {
+              var result = SDL.RadioModel.checkRadioFrequencyBoundaries(
+                request.params.moduleData.radioControlData
+              );
+              if (!result.success) {
                 this.sendError(
                   SDL.SDLModel.data.resultCode.INVALID_DATA,
                   request.id, request.method,
-                  'Invalid radio frequency for desination radio band.'
+                  result.info
                 );
                 return;
               }

--- a/ffw/UIRPC.js
+++ b/ffw/UIRPC.js
@@ -342,45 +342,22 @@ FFW.UI = FFW.RPCObserver.create(
           }
           case 'UI.SetDisplayLayout':
           {
-            var senResponseFlag = false;
+            var sendResponseFlag = false;
             switch (request.params.displayLayout) {
               case 'MEDIA':
-              {
-                senResponseFlag = true;
-                break;
-              }
               case 'NON-MEDIA':
-              {
-                senResponseFlag = true;
-                break;
-              }
               case 'DEFAULT':
-              {
-                senResponseFlag = true;
-                break;
-              }
               case 'ONSCREEN_PRESETS':
-              {
-                senResponseFlag = true;
-                break;
-              }
               case 'NAV_FULLSCREEN_MAP':
-              {
-                senResponseFlag = true;
-                break;
-              }
               case 'NAV_KEYBOARD':
-              {
-                senResponseFlag = true;
-                break;
-              }
               case 'NAV_LIST':
+              case 'REMOTE_CONTROL':
               {
-                senResponseFlag = true;
+                sendResponseFlag = true;
                 break;
               }
             }
-            if (senResponseFlag) {
+            if (sendResponseFlag) {
               Em.Logger.log('FFW.' + request.method + 'Response');
               // send repsonse
               var JSONMessage = {
@@ -795,11 +772,6 @@ FFW.UI = FFW.RPCObserver.create(
                       'upDownAvailable': true
                     }, {
                       'name': 'SEEKLEFT',
-                      'shortPressAvailable': true,
-                      'longPressAvailable': true,
-                      'upDownAvailable': true
-                    }, {
-                      'name': 'PLAY_PAUSE',
                       'shortPressAvailable': true,
                       'longPressAvailable': true,
                       'upDownAvailable': true


### PR DESCRIPTION
Comments from Zhimin:

>  HD radio comes only with FM. And not all FM frequencies have HD radio broadcasting. So HD may be available for some FM frequencies, not available for other FM frequencies.
> For AM and XM, HD shall not been shown.

> Sorry, I was wrong about HD and AM. I did more search on internet. It is possible to have HD on AM. Just most AM frequencies does not have HD signal turned on.
> So please only remove HD from XM pane.
> Whether HD is on AM or HM depending on the initialized data (if HD available in that Frequency, show HD, otherwise hide HD).

In this pull request:
- Update UI in radio view: Added 0 to HD channels to have ability to disable HD channels
for current station, updated station text with HD channels.
- Removed not used data structures
- Now HD channels available for FM and AM bands. For each station HD channels count could be edited or
disabled at all using options menu or set RPC.