### PR TITLE
Fix OnInteriorVehicleData fields including for different bands

### DIFF
--- a/app/controller/sdl/RController.js
+++ b/app/controller/sdl/RController.js
@@ -486,7 +486,8 @@ SDL.RController = SDL.SDLController.extend(
           if (Object.keys(result[key]).length === 0) {
             delete result[key];
           }
-        } else if (properties.indexOf(stack + key) < 0) {
+        } else if (properties.indexOf(stack + key) < 0 &&
+                   properties.indexOf(stack + '*') < 0) {
           delete result[key];
         }
       }

--- a/app/model/media/RadioModel.js
+++ b/app/model/media/RadioModel.js
@@ -545,10 +545,14 @@ SDL.RadioModel = Em.Object.create({
       }
 
       if (forceGetAll || this.radioControlCheckboxes.availableHDs) {
-        result.availableHDs = this.radioControlStruct.availableHDs;
+        if (this.radioControlStruct.availableHDs > 0) {
+          result.availableHDs = this.radioControlStruct.availableHDs;
+        }
       }
       if (forceGetAll || this.radioControlCheckboxes.hdChannel) {
-        result.hdChannel = this.radioControlStruct.hdChannel;
+        if (this.radioControlStruct.hdChannel > 0) {
+          result.hdChannel = this.radioControlStruct.hdChannel;
+        }
       }
       if (forceGetAll || this.radioControlCheckboxes.signalStrength) {
         result.signalStrength = parseInt(this.radioControlStruct.signalStrength);
@@ -1001,11 +1005,27 @@ SDL.RadioModel = Em.Object.create({
     SDL.RadioModel.toggleProperty('radioControlStruct.radioEnable');
     var data = this.getRadioControlData(true);
     data = SDL.SDLController.filterObjectProperty(data, 'band');
-    if (data.band == 'FM' || data.band == 'AM') {
-      this.sendRadioChangeNotification(['radioEnable', 'frequencyInteger', 'frequencyFraction', 'band']);
-    } 
-    else {
-      this.sendRadioChangeNotification(['radioEnable']);
+    if (data.band == 'FM') {
+      this.sendRadioChangeNotification(['radioEnable',
+                                        'frequencyInteger',
+                                        'frequencyFraction',
+                                        'band',
+                                        'availableHDs',
+                                        'hdChannel',
+                                        'rdsData.*']);
+    } else if (data.band == 'AM') {
+      this.sendRadioChangeNotification(['radioEnable',
+                                        'frequencyInteger',
+                                        'band',
+                                        'availableHDs',
+                                        'hdChannel']);
+    } else {
+      this.sendRadioChangeNotification(['radioEnable',
+                                        'frequencyInteger',
+                                        'band',
+                                        'signalStrength',
+                                        'signalChangeThreshold',
+                                        'state']);
     }
   },
 
@@ -1292,29 +1312,30 @@ SDL.RadioModel = Em.Object.create({
   sendFrequencyChangeNotification: function() {
     if (this.radioControlStruct.band === 'FM') {
       this.sendRadioChangeNotification(
-        ['frequencyInteger', 'frequencyFraction']
+        ['frequencyInteger',
+         'frequencyFraction',
+         'availableHDs',
+         'hdChannel']
       );
     }
     if (this.radioControlStruct.band === 'AM') {
-      this.sendRadioChangeNotification(['frequencyInteger']);
+      this.sendRadioChangeNotification(['frequencyInteger',
+                                        'availableHDs',
+                                        'hdChannel']);
     }
     if (this.radioControlStruct.band === 'XM') {
-      this.sendRadioChangeNotification(['hdChannel']);
+      this.sendRadioChangeNotification(['frequencyInteger']);
     }
   },
 
   findStationPresets: function() {
     var i = 0;
     var band = this.radioControlStruct.band;
-    var station = (band == 'XM' ?
-      this.getStation(this.radioControlStruct.frequencyInteger) :
-      this.station
-    );
 
     this.set('activePreset', null);
 
     for (i; i < this.preset[band].length; i++) {
-      if (station == this.preset[band][i]) {
+      if (this.station == this.preset[band][i]) {
         this.set('activePreset', i);
         break;
       }

--- a/app/model/media/RadioModel.js
+++ b/app/model/media/RadioModel.js
@@ -810,7 +810,7 @@ SDL.RadioModel = Em.Object.create({
     }
     if (this.radioControlStruct.band === 'XM') {
       this.set('station',
-        this.getStation(this.radioControlStruct.frequencyInteger).substring(0, 12)
+        this.getStation(this.radioControlStruct.frequencyInteger)
       );
     }
 

--- a/css/media.css
+++ b/css/media.css
@@ -883,6 +883,9 @@
     top: 30px;
     left: 8px;
     position: absolute;
+    white-space: nowrap;
+    overflow: hidden;
+    width: 400px;
 }
 
 .track-info > .genre {
@@ -908,6 +911,9 @@
     top: 50px;
     left: 8px;
     font-size: 62px;
+    white-space: nowrap;
+    overflow: hidden;
+    width: 400px;
 }
 
 #radio_view_container .divider_o {


### PR DESCRIPTION
Comments from Zhimin:

> When radio change from disabled to enabled, HMI may choose to send available data, for example last radio band and station tuned ( AM+ Frequency Integer; FM+ Frequency Integer + Fraction + RDS + HD if available; XM +  channel number(Frequency Integer), radio state, radio signal strength and threshold are optional

> What I see now is :
> if I turn AM radio off and turn on again, I see band=AM + Frequency Integer + Frequency Fraction ( Fraction shall be 0 always for AM, so no need to include Fraction);
> if I turn FM radio off and on again, I see band=FM + Frequency Integer + Frequency Fraction (that’s good, RDS data can be included too);
> if I turn XM radio off and on again, I see band=XM + hdChannel (hdChannel shall not be used here). When I say “last radio band and station”, I means the band(AM/FM/XM) and station (Frequency integer and Fraction) before the radio is turned off.

In this pull request new fields were added for every band for notification RPC.